### PR TITLE
feat: Open Feign Clients API 및 Open AI 프롬프트 질문 생성

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -73,12 +73,12 @@ jobs:
           source: build/libs/*
           strip_components: 1
           target: '/home/ubuntu'
-        #기존 배포 중지
+        #기존 배포 중지s
       - name: Grant execute permission for stop.sh
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.LIGHTSAIL_HOST }}
-          username: ${{env.LIGHTSAIL_USERNAME}}
+          username: ${{ env.LIGHTSAIL_USERNAME }}
           key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
           script: sudo chmod +x dino_stop.sh
 
@@ -97,7 +97,7 @@ jobs:
           username: ${{ env.LIGHTSAIL_USERNAME }}
           key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
           script: echo -e "#!/bin/bash\n
-            export JWT=${{ secrets.JWT}}\n
+            export JWT=${{ secrets.JWT }}\n
             export JWT_EXPIRATION=${{ secrets.JWT_EXPIRATION }} \n
             export JWT_HEADER=${{ secrets.JWT_HEADER }}\n
             export KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}\n
@@ -110,16 +110,18 @@ jobs:
             export S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}\n
             export S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}\n
             export S3_REGION=${{ secrets.S3_REGION }}\n
-            export DATA_SOURCE_URL=${{ secrets.DATA_SOURCE_URL }}\n
-            export DATA_SOURCE_USERNAME=${{ secrets.DATA_SOURCE_USERNAME }}\n
-            export DATA_SOURCE_PW=${{ secrets.DATA_SOURCE_PW }}\n
+            export DB_URL=${{ secrets.DB_URL }}\n
+            export DB_USERNAME=${{ secrets.DB_USERNAME }}\n
+            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}\n
+            export OPENAI_MODEL=${{ secrets.OPENAI_MODEL }}\n
+            export OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}\n
             nohup java -jar ./libs/dino-BE-0.0.1-SNAPSHOT.jar > /home/ubuntu/dio_be.log 2>&1 &" > dino_start.sh
         #생성된 쉘 스크립트에 실행 권한 부여
       - name: Grant execute permission for start.sh
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.LIGHTSAIL_HOST }}
-          username: ${{env.LIGHTSAIL_USERNAME}}
+          username: ${{ env.LIGHTSAIL_USERNAME }}
           key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
           script: sudo chmod +x dino_start.sh
 
@@ -129,7 +131,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.LIGHTSAIL_HOST }}
-          username: ${{env.LIGHTSAIL_USERNAME}}
+          username: ${{ env.LIGHTSAIL_USERNAME }}
           key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
           script: ./dino_start.sh
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
     }
 }
 
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -21,6 +22,18 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+
+//Spring Boot 3.3.x 버전의 호환성에 따른 Spring Cloud 버전을 명시 지정 (2023.0.2)
+ext {
+    set('springCloudVersion', "2023.0.2")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 dependencies {
@@ -38,25 +51,31 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    //AWS S3
+    //AWS SDK
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-    //file upload
+    //File Upload Utility
     implementation 'commons-fileupload:commons-fileupload:1.5'
     implementation 'commons-io:commons-io:2.11.0'
 
-    // jwt
+    //JWT Generator
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // swagger
+    //Swagger
     implementation 'io.springfox:springfox-swagger2:2.9.2'
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    //OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    //JSON parser
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/khu/dino/common/auth/RedirectFromLocal.java
+++ b/src/main/java/khu/dino/common/auth/RedirectFromLocal.java
@@ -9,6 +9,6 @@ public class RedirectFromLocal implements RedirectFromProfile{
 
     @Override
     public String getRedirectUrl() {
-        return "http://localhost";
+        return "http://localhost:3000";
     }
 }

--- a/src/main/java/khu/dino/common/config/OpenAIFeignConfig.java
+++ b/src/main/java/khu/dino/common/config/OpenAIFeignConfig.java
@@ -1,0 +1,32 @@
+
+package khu.dino.common.config;
+
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.charset.StandardCharsets;
+
+
+@Configuration
+public class OpenAIFeignConfig {
+
+    @Value("${openai.api.key}")
+    private String openAIKey;
+
+
+    @Bean
+    public RequestInterceptor requestInterceptor(){
+        return requestTemplate -> {
+            requestTemplate.header("Authorization", "Bearer " + openAIKey);
+            requestTemplate.header("Content-Type", "application/json;charset=utf-8");
+            requestTemplate.header("Accept-Charset", StandardCharsets.UTF_8.name());
+        };
+    }
+
+
+
+}
+

--- a/src/main/java/khu/dino/common/config/OpenFeignClientsConfig.java
+++ b/src/main/java/khu/dino/common/config/OpenFeignClientsConfig.java
@@ -1,0 +1,9 @@
+package khu.dino.common.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableFeignClients(basePackages = "khu.dino")
+public class OpenFeignClientsConfig {
+}

--- a/src/main/java/khu/dino/openai/OpenAIFeignClient.java
+++ b/src/main/java/khu/dino/openai/OpenAIFeignClient.java
@@ -1,0 +1,18 @@
+package khu.dino.openai;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import khu.dino.common.config.OpenAIFeignConfig;
+import khu.dino.openai.presentation.dto.OpenAIRequestDto;
+import khu.dino.openai.presentation.dto.OpenAIResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "openai-client", url = "https://api.openai.com", configuration = OpenAIFeignConfig.class)
+public interface OpenAIFeignClient {
+
+    @PostMapping(value = "/v1/chat/completions")
+    OpenAIResponseDto.OpenAIResponse sendRequest(@RequestBody OpenAIRequestDto.OpenAIRequest request);
+
+}

--- a/src/main/java/khu/dino/openai/presentation/OpenAIApi.java
+++ b/src/main/java/khu/dino/openai/presentation/OpenAIApi.java
@@ -1,0 +1,144 @@
+package khu.dino.openai.presentation;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import khu.dino.openai.OpenAIFeignClient;
+import khu.dino.openai.presentation.dto.OpenAIRequestDto;
+import khu.dino.openai.presentation.dto.OpenAIResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "Open API 목록", description = "Open관련 API 목록입니다.")
+@RequestMapping("/api/v1/open-ai")
+public class OpenAIApi {
+    @Value("${openai.model}")
+    private String openAIModel;
+
+    private final OpenAIFeignClient openAIFeignClient;
+
+
+    /**
+     * OpenAI API 테스트 용
+     * 추후, 도메인 개발 완료 시 이벤트 생성 로직에 적용될 예정
+     * @param eventTitle
+     * @param emotion
+     * @param discription
+     * @param questionSize
+     * @return
+     * @throws java.text.ParseException
+     */
+
+    @Deprecated
+    @Operation(summary="OpenAI API 테스트 용", description = "질문과 감정, 질뭇 갯수에 따른 생성일 발행 API")
+    @GetMapping("/chat")
+    public ResponseEntity<Map<Long, String>> chat(@RequestParam(name = "event-title")String eventTitle, @RequestParam("emotion") String emotion, @RequestParam(value = "discription", required = false)String discription,  @RequestParam(name = "question-size") Integer questionSize) throws java.text.ParseException {
+        OpenAIRequestDto.OpenAIRequestMessage systemMessage = OpenAIRequestDto.OpenAIRequestMessage.builder()
+                .role("system")
+                .content("너는 나에게 이 이벤트와 관련된 질문을 제공해주는 말동무이자 친구 역할이야. 초반에는 해당 일정에 대한 간단한 정보를 묻는 질문이 좋을 것 같고, " +
+                        "후반에는 이 일정에 대한 나의 감정이나 생각을 묻는 질문이 좋을 것 같아. 내가 현재 느끼는 감정으 극대화 시킬 수 있는 단어들로 질문을 구성해 주었으면 좋겠어.")
+                .build();
+        String requestMessageBody = "내가 기대하고 있는 이벤트에 대한 제목은 다음과 같아." + eventTitle +
+                "그리고 내가 현재 이 이벤트를 대하고 있는 마음가짐은 " + emotion +"이야. " +
+                "내가 너로부터 이벤트에 대한 설레는 질문을 받을 갯수는 " + questionSize + "개야. " +
+                (discription == null ? "" :  "해당 이벤트에 대한 부연 설명을 하자면 다음과 같아." +  discription ) +
+                "무엇보다 중요한점은 서버가 받기 용이하게 질문을 JSON 형태로 가공해서 파싱하기 편하게 만들어 줬으면 좋겠어. " +
+                "'questions'이라는 key값에 value는 배열 형태로 주되, 배열 내부 요소는 다시 각각 순서를 나타내는 id와 question이라는 key값으로 반환해 주었으면 해. ";
+        OpenAIRequestDto.OpenAIRequestMessage userMessage = OpenAIRequestDto.OpenAIRequestMessage.builder()
+                .role("user")
+                .content(requestMessageBody)
+                .build();
+        OpenAIRequestDto.OpenAIRequest openAIRequest = OpenAIRequestDto.OpenAIRequest.builder()
+                .model(openAIModel)
+                .messages(List.of(systemMessage, userMessage))
+                .build();
+
+
+        OpenAIResponseDto.OpenAIResponse openAIResponse = openAIFeignClient.sendRequest(openAIRequest);
+
+
+
+
+        // 시작일과 종료일
+        String startDateStr = "2024-09-01";
+        String endDateStr = "2024-09-14";
+
+
+        LocalDate startDate = LocalDate.parse(startDateStr);
+        LocalDate endDate = LocalDate.parse(endDateStr);
+        Map<Long, String> result = getStringStringMap(extractJsonData(openAIResponse.getChoices().get(0).getMessage().getContent()));
+
+
+        long totalDays = ChronoUnit.DAYS.between(startDate, endDate);
+        float interval =  (float) totalDays / ( result.size() -1 );
+
+        List<LocalDate> pushDates = new ArrayList<>();
+
+        LocalDate currentPushDate = startDate.plusDays(1);  // 첫날은 제외하고 시작
+        for (int i = 0; i < result.size()-1; i++) {
+            pushDates.add(currentPushDate.plusDays(Math.round( interval * i)).isEqual(endDate) ? endDate.minusDays(1) : currentPushDate.plusDays(Math.round( interval * i))  ); //우선 담고 보자.
+        }
+        pushDates.add(endDate);
+        for(int i = 0; i < result.size(); i++){
+            log.info("질문 내용 : " + result.get((long) i + 1) + ", 질문 발생일: " + pushDates.get(i));
+        }
+
+        return ResponseEntity.ok(result);
+
+    }
+
+    private  Map<Long, String> getStringStringMap(String result) {
+        JSONParser parser = new JSONParser();
+        Map<Long, String> questionMap = new HashMap<>();
+        try {
+
+            JSONObject jsonObject = (JSONObject) parser.parse(result);
+            JSONArray questionsArray = (JSONArray) jsonObject.get("questions");
+
+            for (Object obj : questionsArray) {
+                JSONObject questionObject = (JSONObject) obj;
+                String question = (String) questionObject.get("question");
+                Long id = (Long) questionObject.get("id");
+                questionMap.put(id, question);
+
+            }
+        } catch (ParseException e) {
+            throw new RuntimeException(e); //추후 에러 반환 처리 필요.
+        }
+        return questionMap;
+    }
+
+
+    private  String extractJsonData(String text) {
+
+        int jsonStart = text.indexOf("```json") ;
+        int jsonEnd = text.lastIndexOf("```");
+
+        return text.substring(jsonStart, jsonEnd).replace("```json", "");
+    }
+
+
+
+}

--- a/src/main/java/khu/dino/openai/presentation/dto/OpenAIRequestDto.java
+++ b/src/main/java/khu/dino/openai/presentation/dto/OpenAIRequestDto.java
@@ -1,0 +1,34 @@
+package khu.dino.openai.presentation.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OpenAIRequestDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @ToString
+    public static class OpenAIRequest{
+        private String model;
+        private List<OpenAIRequestMessage> messages;
+    }
+
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @ToString
+    public static class OpenAIRequestMessage{
+        private String role; //역할
+        private String content; //내용
+
+    }
+}

--- a/src/main/java/khu/dino/openai/presentation/dto/OpenAIResponseDto.java
+++ b/src/main/java/khu/dino/openai/presentation/dto/OpenAIResponseDto.java
@@ -1,0 +1,45 @@
+package khu.dino.openai.presentation.dto;
+
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OpenAIResponseDto {
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @ToString
+    public static class OpenAIResponse{
+        private List<OpenAIResponseDto.OpenAIChoice> choices;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @ToString
+    public static class OpenAIChoice{
+        private int index;
+        private OpenAIResponseMessage message;
+    }
+
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @ToString
+    public static class OpenAIResponseMessage{
+        private String role; //역할
+        private String content; //내용
+
+    }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Feign Client를 통한 OpenAI API와 REST 통신을 수행합니다. 
1. 우선적으로 Spring Cloud의 버전 호환을 위해 build.gradle에서 스프링클라우드 버전을 명시적으로 기술하였으며, 서버 간 통신 시 JSON 가공을 위해 json-simple 의존성을 추가하였습니다.
2. 다음으로 테스트 용으로 OpenAI의 API와의 통신을 위해 프롬프트 템플릿을 생성하였습니다. 
> 이벤트 명, 감정, 질문 갯수, 선택적인 상세 정보 총 4개를 파라미터로 주입받아 해당 이벤트를 생성받고, 시작일과 종료일을 설정하여 균등하게 인터벌을 계산하여 각 질문의 생성일자를 설정합니다.

close #8 
## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- Spring Cloud 버전 호환 검증
- OpenFeignClients 의존성 추가
- json-simple 의존성 추가
- 테스트 용 질문 생성 엔드포인트 생성

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
엔테티 설계가 마친 뒤, 이벤트 생성에 대한 비지니스 로직에 추가될 사항들이 포함되어 있습니다. 
