### PR TITLE
feat: 일정에 실행될 Job 생성 및 스케쥴러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 
     //JSON parser
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+    //Quartz Scheduler
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-quartz', version: '2.3.2.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/khu/dino/common/config/AsyncConfig.java
+++ b/src/main/java/khu/dino/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package khu.dino.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/khu/dino/common/scheduler/PushNotificationJob.java
+++ b/src/main/java/khu/dino/common/scheduler/PushNotificationJob.java
@@ -1,0 +1,17 @@
+package khu.dino.common.scheduler;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+public class PushNotificationJob implements Job {
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+            // 트리거된 푸시 알림 시간
+        String pushDateTime = jobExecutionContext.getJobDetail().getJobDataMap().getString("pushDateTime");
+
+        // 콘솔에 푸시 알림 출력
+        System.out.println("푸쉬 알림이 발생할 시간 " + pushDateTime);
+    }
+
+}

--- a/src/main/java/khu/dino/common/scheduler/PushNotificationScheduler.java
+++ b/src/main/java/khu/dino/common/scheduler/PushNotificationScheduler.java
@@ -1,0 +1,56 @@
+package khu.dino.common.scheduler;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class PushNotificationScheduler {
+
+
+    @Async
+    public void schedulePushNotification(List<LocalDate> pushDates) throws SchedulerException {
+        // 푸시 알림 스케줄링
+        Scheduler scheduler = StdSchedulerFactory.getDefaultScheduler();
+        scheduler.start();
+
+        for(LocalDate pushDate : pushDates) {
+            LocalDateTime pushDateTime = pushDate.atTime(LocalTime.of(12, 0));
+            Date triggerDate = Date.from(pushDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+            // JobDetail 생성
+            JobDetail job = JobBuilder.newJob(PushNotificationJob.class)
+                    .withIdentity("job_" + pushDateTime, "test1") //여기에 사용자 ID_이벤트 ID로 구성
+                    .usingJobData("pushDateTime", pushDateTime.toString())  // PushNotificationJob에서 사용할 데이터
+                    .build();
+
+            // Trigger 생성
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity("trigger_" + pushDateTime, "test1")
+                    .startAt(triggerDate)  // 실행 시간을 설정
+//                    .startAt(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).plusSeconds(10).toInstant()))
+//                    .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+//                            .withMisfireHandlingInstructionFireNow())  // 스케줄이 지났을 경우 즉시 실행
+                    .withSchedule(SimpleScheduleBuilder.simpleSchedule().withRepeatCount(0).withIntervalInSeconds(0).withMisfireHandlingInstructionFireNow())
+                    .build();
+
+            // 스케줄러에 작업과 트리거 등록
+            scheduler.scheduleJob(job, trigger);
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Quartz 의존성 라이브러리를 활용하여 특정 일자에 한 번만 수행되는 스케쥴러를 구현하였습니다. 
## 🔍 작업 내용
<!-- 이 PR의 작업 내용을 적어주세요. -->
- 기존의 질문 생성과 관련된 비지니스 로직에 해당 트리거를 생성하는 메서드를 호출하여 Job을 생성하도록 조치하였습니다. 

## 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
엔티티 설계 이후 질문 생성 엔드포인트가 구현될 시기에 해당 로직은 리팩토링이 필요합니다. 
